### PR TITLE
fix wrapper not found problem for products module settings

### DIFF
--- a/modules/servers/onapp/lib.php
+++ b/modules/servers/onapp/lib.php
@@ -1665,7 +1665,7 @@ function wrapper_check() {
 	global $_LANG;
 
 	if( ! file_exists( ONAPP_WRAPPER_INIT ) ) {
-		$file =  dirname( $_SERVER[ 'SCRIPT_FILENAME' ] ) . '/includes/wrapper/OnAppInit.php';
+		$file =  realpath( dirname( __FILE__ ) . '/../../../' ) . '/includes/wrapper/OnAppInit.php';
 
 		if( file_exists( $file ) ) {
 			require_once $file;

--- a/modules/servers/onapp/onapp.php
+++ b/modules/servers/onapp/onapp.php
@@ -137,12 +137,18 @@ function onapp_ConfigOptions() {
 	$configarray = array();
 
 	if( ! file_exists( ONAPP_WRAPPER_INIT ) ) {
-		return array(
-			sprintf(
-				'%s ' . realpath( dirname( __FILE__ ) . '/../../../' ) . "/includes ( %s )",
-				$_LANG[ 'onappwrappernotfound' ], $_LANG[ 'onappmakesuredirectoryisaccessible' ]
-			) => array()
-		);
+		$file =  realpath( dirname( __FILE__ ) . '/../../../' ) . '/includes/wrapper/OnAppInit.php';
+
+		if( file_exists( $file ) ) {
+			require_once $file;
+		} else {
+			return array(
+				sprintf(
+					'%s ' . realpath( dirname( __FILE__ ) . '/../../../' ) . "/includes ( %s )",
+					$_LANG[ 'onappwrappernotfound' ], $_LANG[ 'onappmakesuredirectoryisaccessible' ]
+				) => array()
+			);
+		}
 	}
 
 	$table_result = onapp_createTables();


### PR DESCRIPTION
When I opened the module settings for an OnApp server product I got a "Wrapper not found" error.
Applying the lines from lib.php line 1664 wrapper_check() also to onapp.php solved the problem.
Maybe wrapper_check() should be moved somewhere else and used consistently by all other files.
